### PR TITLE
Fix an extra underscore getting added to properties that start with double underscores

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -253,7 +253,7 @@ function createTransformerFactory(program: ts.Program, options?: Partial<RenameO
 				throw new Error(`Cannot get symbol for node "${oldProperty.getText()}"`);
 			}
 
-			const oldPropertyName = symbol.escapedName as string;
+			const oldPropertyName = ts.unescapeLeadingUnderscores(symbol.escapedName);
 
 			return createNewNode(oldPropertyName, type, createNode);
 		}

--- a/tests/test-cases/ts-escaped-identifiers/input.ts
+++ b/tests/test-cases/ts-escaped-identifiers/input.ts
@@ -1,0 +1,6 @@
+class DoubleUnderscoreProperty {
+	public __foo: string = "bar";
+}
+
+const testObject = new DoubleUnderscoreProperty();
+export const foo = testObject.__foo + "baz";

--- a/tests/test-cases/ts-escaped-identifiers/output.js
+++ b/tests/test-cases/ts-escaped-identifiers/output.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.foo = void 0;
+var DoubleUnderscoreProperty = /** @class */ (function () {
+    function DoubleUnderscoreProperty() {
+        this._internal___foo = "bar";
+    }
+    return DoubleUnderscoreProperty;
+}());
+var testObject = new DoubleUnderscoreProperty();
+exports.foo = testObject._internal___foo + "baz";


### PR DESCRIPTION
Internally, TypeScript seems to add an extra underscore to identifiers
that start with two underscores and based on
https://github.com/microsoft/TypeScript-wiki/blob/master/API-Breaking-Changes.md#typescript-30
`unescapeLeadingUnderscores` is the type-safe way of reversing this:

"...the typesafe `escapeLeadingUnderscores` and `unescapeLeadingUnderscores`
should be used if the types indicate they are required (as they are used
to convert to or from branded `__String` and `string` types)."

The added test is a bit contrived. I bumped into this issue when disabling
annotations for internal fields (i.e., using `internalPrefix: ""`), yet a field
like `__html` was getting renamed to `___html`.