### PR TITLE
Feature for excluding names

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ const colors: Record<string, string> = {
 // ...
 ```
 
+### exclusionPattern
+
+*Default: `(()=>false)`*
+
+Allows exclusion using a pattern, a string array, or a function.
+
+Examples:
+```
+exceptionList: [ 'class', 'x', 'y']
+exceptionList: /^_pub/
+exceptionList: (name)=>[ 'class', 'x', 'y'].indexOf(name) !== -1
+
+```
+
+
 ## How to use the custom transformer
 
 Unfortunately, TypeScript itself does not currently provide any easy way to use custom transformers (see <https://github.com/Microsoft/TypeScript/issues/14419>).

--- a/package.json
+++ b/package.json
@@ -29,16 +29,17 @@
     "typescript": ">=3.0.0 || >=4.0.0"
   },
   "devDependencies": {
-    "@types/chai": "~4.2.11",
-    "@types/mocha": "~7.0.2",
-    "@types/node": "~13.13.4",
-    "chai": "~4.2.0",
-    "mocha": "~8.0.1",
-    "npm-run-all": "~4.1.5",
-    "rimraf": "~3.0.2",
-    "ts-node": "~8.10.2",
-    "tslint": "~6.1.2",
-    "typescript": "~4.4.3"
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.1.0",
+    "@types/node": "^17.0.21",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "chai": "^4.3.6",
+    "mocha": "^9.2.1",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.7.0",
+    "tslint": "^6.1.3",
+    "typescript": "*"
   },
   "scripts": {
     "clean": "rimraf lib/ dist/",


### PR DESCRIPTION
publicJSDocTag does not meet all use case I have.
For example I use some code like this:
`this.Add('rect', { x:0, y:0, width: rectWidth, height: rectHeight, class: 'rec_class'} );`

I don't want to quote every item like this (this is less readable)
`this.Add('rect', { 'x':0, 'y':0, 'width': rectWidth, 'height': rectHeight, 'class': 'rec_class'} );`

In this usecase I think it is more flexible to use an exlusion from a list, like this in webpack.config.js:
```
          getCustomTransformers: program => ({
              before: [
                  propertiesRenameTransformer(program, { entrySourceFiles: [ './app.ts', './webapp/webapp.ts'],
                  exclusionPattern: [ 'class', 'x', 'y', 'width', 'height'],
                  })
              ]
          })
```